### PR TITLE
737 Final Fix to avoid enter a repeated tags on tech stacks

### DIFF
--- a/src/components/referral/ReferralForm.tsx
+++ b/src/components/referral/ReferralForm.tsx
@@ -314,13 +314,16 @@ const ReferralForm = (props: ReferralFormProps = {}) => {
                                     setTechStack(event.target.value);
                                 }}
                                 onKeyDown={(keyEvent: any) => {
+                                    var standarizedTagsToCompare: string[] = tags.map((tag: string)=>{
+                                        return tag.toUpperCase().split(' ').join('')
+                                    });
                                     if ((keyEvent.charCode || keyEvent.keyCode) === 13) {
                                         keyEvent.preventDefault();
-                                        if (!tags.includes(techStack)) {
+                                        if (!standarizedTagsToCompare.includes(techStack.toUpperCase().split(' ').join(''))) {
                                             setTags((current: string[]) => {
                                                 return [
                                                     ...current,
-                                                    techStack
+                                                    techStack.toUpperCase()
                                                 ]
                                             });
                                         }


### PR DESCRIPTION
It checks against a standardized tags array to prevent the recurrence of tags that contain the same stack but are expressed differently using spaces or capital letters.

To make the tags consistent with how they will be shown, all tags have been changed to uppercase.